### PR TITLE
Add series finale episode plugin

### DIFF
--- a/src/plugins/episodes/series-finale-ready-to-observe/index.js
+++ b/src/plugins/episodes/series-finale-ready-to-observe/index.js
@@ -1,0 +1,36 @@
+import { EpisodePlugin } from '../../core/EpisodePlugin'
+import RecapScene from './scenes/RecapScene'
+import CallToActionScene from './scenes/CallToActionScene'
+
+export default class SeriesFinaleReadyToObserve extends EpisodePlugin {
+  getMetadata() {
+    return {
+      id: 'series-finale-ready-to-observe',
+      title: "Series Finale: You're Ready to Observe!",
+      description:
+        "You've journeyed from Kafka fundamentals to full New Relic Ultra integration! Explore the resources, and elevate your Kafka observability.",
+      seasonNumber: 3,
+      episodeNumber: 3,
+      runtime: 60,
+      level: 'Advanced',
+      tags: ['kafka', 'observability', 'share-groups']
+    }
+  }
+
+  getScenes() {
+    return [
+      {
+        id: 'recap',
+        component: RecapScene,
+        title: 'Journey Recap',
+        duration: 40
+      },
+      {
+        id: 'call-to-action',
+        component: CallToActionScene,
+        title: 'Next Steps',
+        duration: 20
+      }
+    ]
+  }
+}

--- a/src/plugins/episodes/series-finale-ready-to-observe/manifest.json
+++ b/src/plugins/episodes/series-finale-ready-to-observe/manifest.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "name": "series-finale-ready-to-observe",
+  "displayName": "Series Finale: You're Ready to Observe!",
+  "description": "You've journeyed from Kafka fundamentals to full New Relic Ultra integration! Explore the resources, and elevate your Kafka observability.",
+  "author": "TechFlix Team",
+  "episodeClass": "./index.js",
+  "seasonNumber": 3,
+  "episodeNumber": 3,
+  "dependencies": [],
+  "assets": {
+    "thumbnails": [],
+    "images": [],
+    "audio": []
+  },
+  "config": {
+    "runtime": 60,
+    "level": "Advanced"
+  }
+}

--- a/src/plugins/episodes/series-finale-ready-to-observe/scenes/CallToActionScene.jsx
+++ b/src/plugins/episodes/series-finale-ready-to-observe/scenes/CallToActionScene.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+const CallToActionScene = ({ time = 0 }) => (
+  <div className="w-full h-full bg-gradient-to-br from-black via-gray-900 to-purple-900 flex flex-col items-center justify-center text-center p-8 text-white relative overflow-hidden">
+    <h1 className="text-5xl font-extrabold mb-6 bg-gradient-to-r from-green-400 to-teal-400 bg-clip-text text-transparent">
+      Observing Kafka Share Groups with New Relic: Mission Accomplished!
+    </h1>
+    <p className="text-xl mb-8 max-w-3xl">
+      You've journeyed from Kafka fundamentals to full New Relic Ultra integration! Explore the resources, and elevate your Kafka observability.
+    </p>
+    <a
+      href="https://nr.com/kafka-sg-observe"
+      className="text-3xl font-bold text-blue-400 underline animate-pulse"
+      style={{ animationDelay: `${Math.max(0, time - 1)}s` }}
+    >
+      nr.com/kafka-sg-observe
+    </a>
+  </div>
+)
+
+export default CallToActionScene

--- a/src/plugins/episodes/series-finale-ready-to-observe/scenes/RecapScene.jsx
+++ b/src/plugins/episodes/series-finale-ready-to-observe/scenes/RecapScene.jsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react'
+
+const RecapScene = ({ time = 0, duration = 40 }) => {
+  const points = [
+    'Kafka Share Groups fundamentals',
+    'Custom OHI for QueueSample metrics',
+    'Queues & Streams UI integration',
+    'Operational best practices'
+  ]
+
+  const [visibleCount, setVisibleCount] = useState(0)
+
+  useEffect(() => {
+    const index = Math.min(points.length, Math.floor(time / 5))
+    setVisibleCount(index)
+  }, [time])
+
+  return (
+    <div className="w-full h-full bg-gradient-to-br from-purple-900 via-black to-blue-900 flex flex-col items-center justify-center p-8 text-center text-white relative overflow-hidden">
+      <h1 className="text-5xl font-black mb-8 bg-gradient-to-r from-red-500 to-orange-500 bg-clip-text text-transparent">
+        Mission Recap
+      </h1>
+      <ul className="text-2xl space-y-6">
+        {points.slice(0, visibleCount).map((p, i) => (
+          <li key={i} className="opacity-0 animate-fade-in-up" style={{ animationDelay: `${i * 0.3}s`, animationFillMode: 'forwards' }}>
+            {p}
+          </li>
+        ))}
+      </ul>
+      <style jsx>{`
+        @keyframes fade-in-up {
+          from { opacity: 0; transform: translateY(20px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        .animate-fade-in-up { animation: fade-in-up 0.6s ease-out forwards; }
+      `}</style>
+    </div>
+  )
+}
+
+export default RecapScene

--- a/techflix/public/plugins/episodes/registry.json
+++ b/techflix/public/plugins/episodes/registry.json
@@ -6,6 +6,12 @@
       "path": "./src/plugins/episodes/kafka-share-groups",
       "enabled": true,
       "category": "distributed-systems"
+    },
+    {
+      "id": "series-finale-ready-to-observe",
+      "path": "./src/plugins/episodes/series-finale-ready-to-observe",
+      "enabled": true,
+      "category": "distributed-systems"
     }
   ],
   "categories": {


### PR DESCRIPTION
## Summary
- create `series-finale-ready-to-observe` episode plugin
- add basic recap and call-to-action scenes
- include manifest for season 3 episode 3
- register episode in the plugin registry
- **update** plugin with animated recap and CTA scenes

## Testing
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea8b0b48326b6c489cfa7a51782