### PR TITLE
Add kafka evolution limits episode plugin

### DIFF
--- a/techflix/src/plugins/episodes/kafka-evolution-limits/components/interactive/SkipInteractive.jsx
+++ b/techflix/src/plugins/episodes/kafka-evolution-limits/components/interactive/SkipInteractive.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const SkipInteractive = ({ onSkip, label = 'Skip Intro' }) => (
+  <button
+    type="button"
+    className="px-4 py-2 bg-red-600 text-white rounded"
+    onClick={onSkip}
+  >
+    {label}
+  </button>
+);
+
+export default SkipInteractive;

--- a/techflix/src/plugins/episodes/kafka-evolution-limits/index.js
+++ b/techflix/src/plugins/episodes/kafka-evolution-limits/index.js
@@ -1,0 +1,75 @@
+import { EpisodePlugin } from '../../core/EpisodePlugin';
+import KafkaRefresherScene from './scenes/KafkaRefresherScene';
+import TraditionalLimitsScene from './scenes/TraditionalLimitsScene';
+import SkipInteractive from './components/interactive/SkipInteractive';
+
+export default class KafkaEvolutionLimitsEpisode extends EpisodePlugin {
+  getMetadata() {
+    return {
+      id: 'kafka-evolution-limits',
+      title: 'The Evolution & Limitations of Kafka',
+      description: "Explore Kafka's journey from traditional consumer groups to the need for Share Groups",
+      seasonNumber: 1,
+      episodeNumber: 1,
+      duration: 195, // seconds
+      level: 'Intermediate',
+      tags: ['kafka', 'consumer-groups', 'scalability', 'share-groups'],
+      thumbnailUrl: './assets/S1_E1_thumb_episode-thumbnail.jpg',
+      releaseDate: '2024-02-01',
+      prerequisites: ['Basic messaging concepts'],
+      learningOutcomes: [
+        'Understand traditional Kafka consumer group architecture',
+        'Identify scalability limitations',
+        'Recognize when Share Groups are needed'
+      ]
+    };
+  }
+
+  getScenes() {
+    return [
+      {
+        id: 'kafka-refresher',
+        type: 'intro',
+        component: KafkaRefresherScene,
+        title: 'Kafka Refresher / Jump Ahead',
+        duration: 45,
+        category: 'Introduction',
+        description: 'Optional Kafka fundamentals refresher with skip option',
+        narration: 'New to Kafka or need a quick primer? Great!',
+        mood: 'epic-intro',
+        backgroundImage: './assets/S1_E1_S1_bg_kafka-universe.jpg'
+      },
+      {
+        id: 'traditional-limits',
+        type: 'content',
+        component: TraditionalLimitsScene,
+        title: 'Traditional Consumer Group Limits',
+        duration: 150,
+        category: 'Core Concepts',
+        description: 'Understanding the bottlenecks of traditional consumer groups',
+        narration: 'Imagine Kafka partitions as highway lanes...',
+        mood: 'tension-building'
+      }
+    ];
+  }
+
+  getInteractiveElements() {
+    return [
+      {
+        id: 'skip-intro',
+        sceneId: 'kafka-refresher',
+        timestamp: 3,
+        component: SkipInteractive,
+        duration: 10,
+        data: {
+          skipToScene: 'traditional-limits',
+          buttonText: 'Kafka Pro? Jump to Share Groups',
+          analytics: {
+            action: 'skip_intro',
+            category: 'navigation'
+          }
+        }
+      }
+    ];
+  }
+}

--- a/techflix/src/plugins/episodes/kafka-evolution-limits/manifest.json
+++ b/techflix/src/plugins/episodes/kafka-evolution-limits/manifest.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0.0",
+  "name": "kafka-evolution-limits",
+  "displayName": "The Evolution & Limitations of Kafka",
+  "description": "Explore Kafka's journey from traditional consumer groups to the need for Share Groups",
+  "author": "TechFlix Team",
+  "episodeClass": "./index.js",
+  "seasonNumber": 1,
+  "episodeNumber": 1,
+  "dependencies": [],
+  "assets": {
+    "thumbnails": ["./assets/S1_E1_thumb_episode-thumbnail.jpg"],
+    "images": [
+      "./assets/S1_E1_S1_svg_kafka-timeline.svg",
+      "./assets/S1_E1_S2_svg_traffic-jam-visualization.svg"
+    ],
+    "audio": [
+      "./assets/S1_E1_S1_audio_narration.mp3",
+      "./assets/S1_E1_S1_audio_bgm-epic-intro.mp3",
+      "./assets/S1_E1_S2_audio_narration.mp3",
+      "./assets/S1_E1_S2_audio_bgm-tension-building.mp3"
+    ]
+  },
+  "config": {
+    "runtime": 3.25,
+    "level": "Intermediate",
+    "tags": ["kafka", "consumer-groups", "scalability", "share-groups"],
+    "voiceOverArtist": "TechFlix Narrator A",
+    "backgroundMusicVolume": 0.3
+  }
+}

--- a/techflix/src/plugins/episodes/kafka-evolution-limits/scenes/KafkaRefresherScene.jsx
+++ b/techflix/src/plugins/episodes/kafka-evolution-limits/scenes/KafkaRefresherScene.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const KafkaRefresherScene = ({ time = 0, duration = 45 }) => {
+  const progress = Math.min((time / duration) * 100, 100);
+  return (
+    <motion.div
+      className="scene-container kafka-refresher flex items-center justify-center"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="text-center">
+        <h2 className="text-2xl font-bold mb-2">Kafka Refresher</h2>
+        <p className="text-sm text-gray-400">Placeholder scene content</p>
+        <div className="h-1 bg-gray-700 rounded mt-4 w-64">
+          <div className="h-full bg-red-500" style={{ width: `${progress}%` }} />
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default KafkaRefresherScene;

--- a/techflix/src/plugins/episodes/kafka-evolution-limits/scenes/TraditionalLimitsScene.jsx
+++ b/techflix/src/plugins/episodes/kafka-evolution-limits/scenes/TraditionalLimitsScene.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const TraditionalLimitsScene = ({ time = 0, duration = 150 }) => {
+  const progress = Math.min((time / duration) * 100, 100);
+  return (
+    <motion.div
+      className="scene-container traditional-limits flex items-center justify-center"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="text-center">
+        <h2 className="text-2xl font-bold mb-2">Traditional Consumer Group Limits</h2>
+        <p className="text-sm text-gray-400">Placeholder explanation of limitations.</p>
+        <div className="h-1 bg-gray-700 rounded mt-4 w-64">
+          <div className="h-full bg-blue-500" style={{ width: `${progress}%` }} />
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default TraditionalLimitsScene;

--- a/techflix/src/plugins/episodes/registry.json
+++ b/techflix/src/plugins/episodes/registry.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "episodes": [
+    {
+      "id": "kafka-evolution-limits",
+      "path": "./kafka-evolution-limits",
+      "enabled": true,
+      "category": "distributed-systems"
+    }
+  ],
+  "categories": {
+    "distributed-systems": {
+      "name": "Distributed Systems",
+      "description": "Episodes about distributed systems architecture and patterns"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement episode plugin for kafka evolution limits
- include manifest.json per outline
- add placeholder scenes with framer-motion
- add SkipInteractive component
- register the episode in plugin registry

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea2c33c832691532985fc2c57f9