### PR TITLE
Implement key-shifts-critical-metrics episode plugin

### DIFF
--- a/techflix/public/plugins/episodes/registry.json
+++ b/techflix/public/plugins/episodes/registry.json
@@ -6,6 +6,12 @@
       "path": "./src/plugins/episodes/kafka-share-groups",
       "enabled": true,
       "category": "distributed-systems"
+    },
+    {
+      "id": "key-shifts-critical-metrics",
+      "path": "./src/plugins/episodes/key-shifts-critical-metrics",
+      "enabled": true,
+      "category": "distributed-systems"
     }
   ],
   "categories": {

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/index.js
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/index.js
@@ -1,0 +1,45 @@
+import TradeOffsScene from './scenes/TradeOffsScene.jsx';
+import MetricSpotlightScene from './scenes/MetricSpotlightScene.jsx';
+import ZeroLagFallacyScene from './scenes/ZeroLagFallacyScene.jsx';
+import ModuleRecapScene from './scenes/ModuleRecapScene.jsx';
+
+export const keyShiftsCriticalMetricsEpisode = {
+  metadata: {
+    seriesId: 'tech-insights',
+    seasonNumber: 1,
+    episodeNumber: 3,
+    title: 'Key Shifts & Critical Metrics',
+    synopsis: 'Understand trade-offs of Share Groups and learn the vital metrics to monitor.',
+    runtime: 300,
+    rating: 'Advanced',
+    genres: ['Kafka', 'Share Groups', 'Metrics']
+  },
+  scenes: [
+    {
+      id: 'trade-offs',
+      title: 'Trade-offs',
+      duration: 75,
+      component: TradeOffsScene
+    },
+    {
+      id: 'metric-spotlight',
+      title: 'Metric Spotlight',
+      duration: 90,
+      component: MetricSpotlightScene
+    },
+    {
+      id: 'zero-lag-fallacy',
+      title: 'Zero Lag Fallacy',
+      duration: 75,
+      component: ZeroLagFallacyScene
+    },
+    {
+      id: 'module-recap',
+      title: 'Module Recap',
+      duration: 60,
+      component: ModuleRecapScene
+    }
+  ]
+};
+
+export default keyShiftsCriticalMetricsEpisode;

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/manifest.json
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0",
+  "name": "key-shifts-critical-metrics",
+  "displayName": "Key Shifts & Critical Metrics",
+  "description": "Scenes covering trade-offs, critical metrics, the zero lag fallacy, and a module recap.",
+  "author": "TechFlix Team",
+  "episodeClass": "./index.js",
+  "seasonNumber": 1,
+  "episodeNumber": 3,
+  "dependencies": [],
+  "assets": {
+    "thumbnails": [],
+    "images": [],
+    "audio": []
+  },
+  "config": {
+    "runtime": 5,
+    "level": "Intermediate",
+    "tags": ["kafka", "share-groups", "metrics"]
+  }
+}

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/MetricSpotlightScene.jsx
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/MetricSpotlightScene.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+
+const MetricSpotlightScene = ({ time, duration }) => {
+  const progress = (time / duration) * 100;
+  const targets = [120, 5000];
+  const [values, setValues] = useState([0, 0]);
+
+  const metrics = [
+    { label: 'RecordsUnacked', icon: '📊' },
+    { label: 'OldestUnackedMessageAgeMs', icon: '⏱️' }
+  ];
+
+  useEffect(() => {
+    const eased = 1 - Math.pow(1 - Math.min(time / duration, 1), 4);
+    setValues(targets.map(t => Math.floor(t * eased)));
+  }, [time, duration]);
+
+  return (
+    <div className="w-full h-full bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-8">
+      <div className="w-full max-w-4xl text-center">
+        <h1 className="text-4xl font-black mb-8 text-white" style={{ opacity: Math.min(time * 0.5, 1) }}>
+          Metric Spotlight
+        </h1>
+        <div className="grid grid-cols-2 gap-8">
+          {metrics.map((metric, idx) => (
+            <div
+              key={idx}
+              className="bg-gray-900/70 rounded-2xl p-6 border border-gray-700"
+            >
+              <div className="text-3xl mb-4">{metric.icon}</div>
+              <div className="text-5xl font-bold text-green-400 mb-2">
+                {values[idx]}
+              </div>
+              <div className="text-sm text-gray-300">{metric.label}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-10">
+          <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-purple-600 to-blue-600 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MetricSpotlightScene;

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/ModuleRecapScene.jsx
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/ModuleRecapScene.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+const ModuleRecapScene = ({ time, duration }) => {
+  const progress = (time / duration) * 100;
+  const points = [
+    'Share Groups enable cooperative consumption',
+    'ACK/RELEASE/REJECT provide fine control',
+    'Watch RecordsUnacked & OldestUnackedMs',
+    'Traditional lag can mislead'
+  ];
+
+  return (
+    <div className="w-full h-full bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-8">
+      <div className="w-full max-w-3xl text-center">
+        <h1 className="text-4xl font-black mb-6 text-white" style={{ opacity: Math.min(time * 0.5, 1) }}>
+          Module 1 Recap
+        </h1>
+        <ul className="text-left text-gray-200 list-disc list-inside space-y-2">
+          {points.map((p, idx) => {
+            const visible = time > idx * 1.2;
+            return (
+              <li
+                key={idx}
+                style={{
+                  opacity: visible ? 1 : 0,
+                  transform: visible ? 'translateY(0)' : 'translateY(20px)',
+                  transition: 'all 0.3s ease-out'
+                }}
+              >
+                {p}
+              </li>
+            );
+          })}
+        </ul>
+        <div className="mt-10">
+          <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-blue-600 to-purple-600 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ModuleRecapScene;

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/TradeOffsScene.jsx
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/TradeOffsScene.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const TradeOffsScene = ({ time, duration }) => {
+  const progress = (time / duration) * 100;
+  const rows = [
+    { label: 'Parallelism', share: 'High', traditional: 'Limited' },
+    { label: 'Ordering', share: 'Flexible \u2194', traditional: 'Strict \u2192', highlight: true },
+    { label: 'Scalability', share: 'Elastic', traditional: 'Partition-bound' },
+    { label: 'Complexity', share: 'ACK/RELEASE logic', traditional: 'Offset commits' }
+  ];
+
+  const revealCount = Math.floor((time / duration) * rows.length);
+
+  return (
+    <div className="w-full h-full bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-8">
+      <div className="w-full max-w-3xl">
+        <h1 className="text-4xl font-black text-center mb-6 text-white" style={{ opacity: Math.min(time * 0.5, 1) }}>
+          Share Groups vs. Traditional
+        </h1>
+        <table className="w-full text-sm text-left text-gray-200 border-collapse">
+          <thead>
+            <tr>
+              <th className="p-3">Aspect</th>
+              <th className="p-3 bg-green-900/40">Share Groups</th>
+              <th className="p-3 bg-red-900/40">Traditional</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const visible = idx < revealCount;
+              return (
+                <tr
+                  key={idx}
+                  className={`border-t border-gray-700 ${row.highlight ? 'bg-yellow-800/20 animate-pulse' : ''}`}
+                  style={{
+                    opacity: visible ? 1 : 0,
+                    transform: visible ? 'translateY(0)' : 'translateY(20px)',
+                    transition: 'all 0.3s ease-out'
+                  }}
+                >
+                  <td className="p-3 font-semibold">{row.label}</td>
+                  <td className="p-3">{row.share}</td>
+                  <td className="p-3">{row.traditional}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <div className="mt-8">
+          <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-green-600 to-blue-600 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TradeOffsScene;

--- a/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/ZeroLagFallacyScene.jsx
+++ b/techflix/src/plugins/episodes/key-shifts-critical-metrics/scenes/ZeroLagFallacyScene.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const ZeroLagFallacyScene = ({ time, duration }) => {
+  const progress = (time / duration) * 100;
+
+  return (
+    <div className="w-full h-full bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center p-8">
+      <div className="w-full max-w-4xl text-center">
+        <h1 className="text-4xl font-black mb-8 text-white" style={{ opacity: Math.min(time * 0.5, 1) }}>
+          The Zero Lag Fallacy
+        </h1>
+        <div className="grid grid-cols-2 gap-8 mb-6">
+          <div className="bg-gray-900/70 rounded-2xl p-6 border border-gray-700">
+            <div className="text-xl text-gray-300 mb-2">Traditional Lag</div>
+            <div className="text-6xl font-bold text-green-500">0</div>
+          </div>
+          <div className="bg-gray-900/70 rounded-2xl p-6 border border-gray-700 animate-pulse">
+            <div className="text-xl text-gray-300 mb-2">RecordsUnacked</div>
+            <div className="text-6xl font-bold text-red-500">500</div>
+          </div>
+        </div>
+        <p
+          className="text-yellow-400"
+          style={{ opacity: Math.min((time - 2) * 0.5, 1) }}
+        >
+          Zero lag can hide problems. Watch the unacked metrics instead!
+        </p>
+        <div className="mt-10">
+          <div className="h-1 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-red-600 to-yellow-500 rounded-full transition-all duration-300"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ZeroLagFallacyScene;


### PR DESCRIPTION
## Summary
- add new plugin `key-shifts-critical-metrics`
- implement TradeOffsScene, MetricSpotlightScene, ZeroLagFallacyScene, ModuleRecapScene
- expose episode metadata and manifest for season 1 episode 3
- register plugin in episode registry
- animate table rows, metric counters, warnings, and recap bullets

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea4a2cc8326bc5dbba750fc9cb7