### PR TITLE
Add Kafka JMX exploration episode

### DIFF
--- a/src/plugins/episodes/kafka-jmx-exploration/index.js
+++ b/src/plugins/episodes/kafka-jmx-exploration/index.js
@@ -1,0 +1,58 @@
+import JMXExplorerScene from './scenes/JMXExplorerScene';
+import MBeanNavigatorScene from './scenes/MBeanNavigatorScene';
+import MetricsVisualizerScene from './scenes/MetricsVisualizerScene';
+
+export const kafkaJmxExplorationEpisode = {
+  metadata: {
+    id: 'kafka-jmx-exploration',
+    title: 'Peeking Inside Kafka: JMX Metrics',
+    description: 'Master JMX to extract critical Share Group metrics from Kafka',
+    seasonNumber: 2,
+    episodeNumber: 1,
+    duration: 225,
+    level: 'Advanced',
+    tags: ['kafka', 'jmx', 'monitoring', 'metrics'],
+    prerequisites: ['Understanding of Kafka Share Groups', 'Basic JMX knowledge'],
+    learningOutcomes: [
+      "Navigate Kafka's JMX MBean structure",
+      'Identify Share Group specific MBeans',
+      'Extract RecordsUnacked and OldestUnackedMs metrics'
+    ]
+  },
+  scenes: [
+    {
+      id: 'jmx-intro',
+      type: 'content',
+      component: JMXExplorerScene,
+      title: "JMX: Kafka's Internal Telemetry",
+      duration: 75,
+      mood: 'technical-deep-dive',
+      narration: 'Kafka reveals its vital signs via JMX...'
+    },
+    {
+      id: 'mbean-navigation',
+      type: 'interactive',
+      component: MBeanNavigatorScene,
+      title: 'Navigating Share Group MBeans',
+      duration: 90,
+      mood: 'technical-deep-dive',
+      interactiveElements: [{
+        type: 'tree-navigation',
+        allowExpand: true,
+        highlightPaths: [
+          'kafka.server:type=share-group-metrics'
+        ]
+      }]
+    },
+    {
+      id: 'metrics-extraction',
+      type: 'demo',
+      component: MetricsVisualizerScene,
+      title: 'Extracting Key Metrics',
+      duration: 60,
+      mood: 'technical-deep-dive'
+    }
+  ]
+};
+
+export default kafkaJmxExplorationEpisode;

--- a/src/plugins/episodes/kafka-jmx-exploration/scenes/JMXExplorerScene.jsx
+++ b/src/plugins/episodes/kafka-jmx-exploration/scenes/JMXExplorerScene.jsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+
+const JMXExplorerScene = ({ time, duration }) => {
+  const [showCommand, setShowCommand] = useState(false);
+
+  useEffect(() => {
+    if (time > 10) setShowCommand(true);
+  }, [time]);
+
+  return (
+    <div className="p-8 text-gray-200">
+      <h2 className="text-3xl font-bold mb-4">JMX Metrics Explorer</h2>
+      <p className="mb-4">Connect to Kafka's JMX port to inspect runtime metrics.</p>
+      {showCommand && (
+        <pre className="bg-gray-900 p-4 rounded">
+          jconsole localhost:9999
+        </pre>
+      )}
+    </div>
+  );
+};
+
+export default JMXExplorerScene;

--- a/src/plugins/episodes/kafka-jmx-exploration/scenes/MBeanNavigatorScene.jsx
+++ b/src/plugins/episodes/kafka-jmx-exploration/scenes/MBeanNavigatorScene.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+const nodes = {
+  'kafka.server': {
+    children: {
+      'type=share-group-metrics': {
+        children: {
+          'group=my-group': {}
+        }
+      }
+    }
+  }
+};
+
+const renderNode = (path, data, expanded, toggle) => {
+  const isExpanded = expanded.includes(path);
+  const hasChildren = data.children && Object.keys(data.children).length > 0;
+  return (
+    <div key={path} className="ml-4">
+      <div onClick={() => toggle(path)} className="cursor-pointer">
+        {hasChildren && (isExpanded ? '▼' : '▶')} {path.split('.').slice(-1)}
+      </div>
+      {isExpanded && hasChildren && (
+        <div className="ml-4">
+          {Object.entries(data.children).map(([child, childData]) =>
+            renderNode(`${path}.${child}`, childData, expanded, toggle)
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const MBeanNavigatorScene = () => {
+  const [expanded, setExpanded] = useState(['kafka.server']);
+
+  const toggle = (path) => {
+    setExpanded((prev) =>
+      prev.includes(path) ? prev.filter((p) => p !== path) : [...prev, path]
+    );
+  };
+
+  return (
+    <div className="p-8 text-gray-200">
+      <h2 className="text-3xl font-bold mb-4">MBean Navigator</h2>
+      {renderNode('kafka.server', nodes['kafka.server'], expanded, toggle)}
+    </div>
+  );
+};
+
+export default MBeanNavigatorScene;

--- a/src/plugins/episodes/kafka-jmx-exploration/scenes/MetricsVisualizerScene.jsx
+++ b/src/plugins/episodes/kafka-jmx-exploration/scenes/MetricsVisualizerScene.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const MetricsVisualizerScene = ({ time }) => {
+  const metrics = {
+    RecordsUnacked: 245,
+    OldestUnackedMessageAgeMs: 15234
+  };
+
+  return (
+    <div className="p-8 text-gray-200">
+      <h2 className="text-3xl font-bold mb-4">Metrics Extraction</h2>
+      <p className="mb-2">RecordsUnacked: {metrics.RecordsUnacked}</p>
+      <p>OldestUnackedMessageAgeMs: {metrics.OldestUnackedMessageAgeMs}</p>
+    </div>
+  );
+};
+
+export default MetricsVisualizerScene;

--- a/techflix/public/plugins/episodes/registry.json
+++ b/techflix/public/plugins/episodes/registry.json
@@ -6,6 +6,12 @@
       "path": "./src/plugins/episodes/kafka-share-groups",
       "enabled": true,
       "category": "distributed-systems"
+    },
+    {
+      "id": "kafka-jmx-exploration",
+      "path": "./src/plugins/episodes/kafka-jmx-exploration",
+      "enabled": true,
+      "category": "distributed-systems"
     }
   ],
   "categories": {


### PR DESCRIPTION
## Summary
- refactor Kafka JMX exploration plugin to match episode object style
- ensure plugin registry newline

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea55e6c8326be623b496b7518ea