### PR TITLE
Add data ingestion paths episode

### DIFF
--- a/techflix/public/plugins/episodes/registry.json
+++ b/techflix/public/plugins/episodes/registry.json
@@ -6,6 +6,12 @@
       "path": "./src/plugins/episodes/kafka-share-groups",
       "enabled": true,
       "category": "distributed-systems"
+    },
+    {
+      "id": "data-ingestion-paths",
+      "path": "./src/plugins/episodes/data-ingestion-paths",
+      "enabled": true,
+      "category": "data-engineering"
     }
   ],
   "categories": {

--- a/techflix/src/plugins/episodes/data-ingestion-paths/index.js
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/index.js
@@ -1,0 +1,44 @@
+import FlexIngestionScene from './scenes/FlexIngestionScene'
+import NRQLDemoScene from './scenes/NRQLDemoScene'
+import NriKafkaReminderScene from './scenes/NriKafkaReminderScene'
+import ModuleRecapScene from './scenes/ModuleRecapScene'
+export const dataIngestionPathsEpisode = {
+  metadata: {
+    seriesId: 'tech-insights',
+    seasonNumber: 2,
+    episodeNumber: 3,
+    title: 'Data Ingestion Paths: Kafka to New Relic',
+    synopsis: 'Different ways metrics flow depending on Kafka hosting.',
+    runtime: 270,
+    rating: 'Intermediate',
+    genres: ['kafka', 'monitoring', 'new relic']
+  },
+  scenes: [
+    {
+      id: 'flex-ingestion',
+      title: 'Quick Visibility with Flex',
+      duration: 75,
+      component: FlexIngestionScene
+    },
+    {
+      id: 'nrql-demo',
+      title: 'RecordsUnacked Live in NRQL',
+      duration: 75,
+      component: NRQLDemoScene
+    },
+    {
+      id: 'nri-kafka-reminder',
+      title: 'nri-kafka Reminder',
+      duration: 60,
+      component: NriKafkaReminderScene
+    },
+    {
+      id: 'module-recap',
+      title: 'Module 2 Recap',
+      duration: 60,
+      component: ModuleRecapScene
+    }
+  ]
+}
+
+export default dataIngestionPathsEpisode

--- a/techflix/src/plugins/episodes/data-ingestion-paths/manifest.json
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0",
+  "name": "data-ingestion-paths",
+  "displayName": "Data Ingestion Paths: Kafka to New Relic",
+  "description": "Different ways metrics flow depending on Kafka hosting.",
+  "author": "TechFlix Team",
+  "episodeClass": "./index.js",
+  "seasonNumber": 2,
+  "episodeNumber": 3,
+  "dependencies": [],
+  "assets": {
+    "thumbnails": [],
+    "images": [],
+    "audio": []
+  },
+  "config": {
+    "runtime": 4.5,
+    "level": "Intermediate",
+    "tags": ["kafka", "monitoring", "new relic"]
+  }
+}

--- a/techflix/src/plugins/episodes/data-ingestion-paths/scenes/FlexIngestionScene.jsx
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/scenes/FlexIngestionScene.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const FlexIngestionScene = () => (
+  <div className="w-full h-full flex items-center justify-center bg-gray-900 text-white p-8">
+    <div className="max-w-2xl text-center">
+      <h2 className="text-3xl font-bold mb-4">Quick Visibility: Flex for Raw Prometheus Metrics</h2>
+      <p className="text-lg text-gray-300">
+        Need insights now? New Relic Flex pulls Prometheus metrics straight into actionable dashboards.
+      </p>
+    </div>
+  </div>
+)
+
+export default FlexIngestionScene

--- a/techflix/src/plugins/episodes/data-ingestion-paths/scenes/ModuleRecapScene.jsx
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/scenes/ModuleRecapScene.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const ModuleRecapScene = () => (
+  <div className="w-full h-full flex items-center justify-center bg-gray-900 text-white p-8">
+    <div className="max-w-2xl text-center">
+      <h2 className="text-3xl font-bold mb-4">Module 2 Recap: Metrics Unleashed</h2>
+      <p className="text-lg text-gray-300">
+        You've successfully tapped into Kafka's core metrics and seen them in New Relic.
+      </p>
+    </div>
+  </div>
+)
+
+export default ModuleRecapScene

--- a/techflix/src/plugins/episodes/data-ingestion-paths/scenes/NRQLDemoScene.jsx
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/scenes/NRQLDemoScene.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const NRQLDemoScene = () => (
+  <div className="w-full h-full flex items-center justify-center bg-gray-900 text-white p-8">
+    <div className="max-w-2xl text-center">
+      <h2 className="text-3xl font-bold mb-4">Mini-Demo: RecordsUnacked Live in NRQL</h2>
+      <p className="text-lg text-gray-300">
+        A quick NRQL query shows your <code>RecordsUnacked</code> metrics trending in real time.
+      </p>
+    </div>
+  </div>
+)
+
+export default NRQLDemoScene

--- a/techflix/src/plugins/episodes/data-ingestion-paths/scenes/NriKafkaReminderScene.jsx
+++ b/techflix/src/plugins/episodes/data-ingestion-paths/scenes/NriKafkaReminderScene.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const NriKafkaReminderScene = () => (
+  <div className="w-full h-full flex items-center justify-center bg-gray-900 text-white p-8">
+    <div className="max-w-2xl text-center">
+      <h2 className="text-3xl font-bold mb-4">Reminder: nri-kafka & Share Group Specifics</h2>
+      <p className="text-lg text-gray-300">
+        The standard <code>nri-kafka</code> integration needs custom configuration for these metrics.
+      </p>
+    </div>
+  </div>
+)
+
+export default NriKafkaReminderScene


### PR DESCRIPTION
## Summary
- fix episode export structure to match refactored episodes
- Data Ingestion Paths episode uses scenes for Flex ingestion, NRQL demo, nri-kafka reminder and module recap
- register the plugin in the public registry

## Testing
- `npm run lint` *(fails: couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea76cac8326881e8a6cee6f30e2